### PR TITLE
Pipes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './result';
 export * from './option';
 export * from './match';
 export * from './unit';
+export * from './pipes';

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -1,2 +1,8 @@
-export const pipe = (value: any, ...fns: Function[]) =>
-  fns.reduce((acc, fn) => fn(acc), value);
+type Fn = (...args: any[]) => any;
+
+type LastReturnType<L extends Fn[]> = L extends [...any, infer Last extends Fn]
+  ? ReturnType<Last>
+  : never;
+
+const pipe = <Funcs extends Fn[]>(value: any, ...fns: Funcs) =>
+  fns.reduce((acc, fn) => fn(acc), value) as LastReturnType<Funcs>;

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -1,0 +1,2 @@
+export const pipe = (value: any, ...fns: Function[]) =>
+  fns.reduce((acc, fn) => fn(acc), value);

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -1,8 +1,25 @@
 type Fn = (...args: any[]) => any;
 
-type LastReturnType<L extends Fn[]> = L extends [...any, infer Last extends Fn]
-  ? ReturnType<Last>
-  : never;
+interface Pipe {
+    <A>(value: A): A;
+    <A, B>(value: A, fn1: (input: A) => B): B;
+    <A, B, C>(value: A, fn1: (input: A) => B, fn2: (input: B) => C): C;
+    <A, B, C, D>(
+        value: A,
+        fn1: (input: A) => B,
+        fn2: (input: B) => C,
+        fn3: (input: C) => D
+    ): D;
+    <A, B, C, D, E>(
+        value: A,
+        fn1: (input: A) => B,
+        fn2: (input: B) => C,
+        fn3: (input: C) => D,
+        fn4: (input: D) => E
+    ): E;
+}
 
-export const pipe = <Funcs extends Fn[]>(value: any, ...fns: Funcs) =>
-  fns.reduce((acc, fn) => fn(acc), value) as LastReturnType<Funcs>;
+export const pipe: Pipe = (value: any, ...fns: Function[]): unknown => {
+    return fns.reduce((acc, fn) => fn(acc), value);
+};
+  

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -4,5 +4,5 @@ type LastReturnType<L extends Fn[]> = L extends [...any, infer Last extends Fn]
   ? ReturnType<Last>
   : never;
 
-const pipe = <Funcs extends Fn[]>(value: any, ...fns: Funcs) =>
+export const pipe = <Funcs extends Fn[]>(value: any, ...fns: Funcs) =>
   fns.reduce((acc, fn) => fn(acc), value) as LastReturnType<Funcs>;

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -19,6 +19,26 @@ interface Pipe {
     ): E;
 }
 
+/**
+ * Represents a function that pipes a value through a series of functions.
+ * @param {any} value - The initial value to be processed.
+ * @param {...Function} fns - Functions to be applied sequentially to the value.
+ * @returns {unknown} The result after applying all functions to the initial value.
+ * @typedef {Function} Pipe
+ * 
+ * @example
+ * const addTwo = (x) => x + 2;
+ * const multiplyByThree = (x) => x * 3;
+ * const square = (x) => x * x;
+ *
+ * const result = pipe(
+ *    2,
+ *    addTwo, // 4
+ *    multiplyByThree, // 12
+ *    square // 144
+ * );
+ * 
+ */
 export const pipe: Pipe = (value: any, ...fns: Function[]): unknown => {
     return fns.reduce((acc, fn) => fn(acc), value);
 };

--- a/tests/pipes.test.ts
+++ b/tests/pipes.test.ts
@@ -15,4 +15,14 @@ describe('pipe construction', () => {
 
     expect(res).toBe(16);
   });
+
+  it('pipe should handle async functions', async () => {
+    const res = await pipe(
+      2,
+      async (a) => await a + 2,
+      async (b) => await b * 3,
+    );
+
+    expect(res).toBe(12);
+  });
 });

--- a/tests/pipes.test.ts
+++ b/tests/pipes.test.ts
@@ -42,4 +42,19 @@ describe('pipe construction', () => {
 
     expect(res).toBe(6 || 12);
   });
+
+  it('nested pipes', async () => {
+    
+    const res = await pipe(
+      2,
+      (a) => a + 3,
+      (b) => pipe(
+        b,
+        (c) => c * 3,
+        (d) => d > 10 ? true : false
+      )
+    );
+
+    expect(res).toBe(true);
+  });
 });

--- a/tests/pipes.test.ts
+++ b/tests/pipes.test.ts
@@ -1,0 +1,18 @@
+import { pipe } from "@carbonteq/fp/pipes";
+
+describe('pipe construction', () => {
+  it('pipe should handle transformation functions', () => {
+    const len = (s: string): number => s.length;
+    const double = (n: number): number => n * 2;
+    const square = (n: number): number => n ** 2;
+    
+    const res = pipe(
+      "hi",
+      len,
+      double,
+      square
+    );
+
+    expect(res).toBe(16);
+  });
+});

--- a/tests/pipes.test.ts
+++ b/tests/pipes.test.ts
@@ -25,4 +25,21 @@ describe('pipe construction', () => {
 
     expect(res).toBe(12);
   });
+
+  it('pipe should handle complex transformation functions', async () => {
+    const res = await pipe(
+      2,
+      (a) => {
+        const x = Math.pow(2, 2);
+        const y = Math.random();
+        if (y > 0.5) {
+          return x;
+        }
+        return a;
+      },
+      async (b) => await b * 3,
+    );
+
+    expect(res).toBe(6 || 12);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,


### PR DESCRIPTION
implemented  #8. It's a pretty useful operator in FP languages, especially Elixir's pipe operator. I wanted to do this without function overloading, but type checking for inputs does not work in that case. Most of the implementations I've seen including fp-ts are doing function overloading to achieve type safety for inputs.